### PR TITLE
Expose os_type

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library (name ppx_optcomp) (public_name ppx_optcomp)
- (libraries compiler-libs.common base ppxlib stdio) (kind ppx_deriver)
+ (libraries unix compiler-libs.common base ppxlib stdio) (kind ppx_deriver)
  (preprocess no_preprocessing))

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -37,6 +37,9 @@ module Value = struct
       (fun major minor patchlevel -> Tuple [Int major; Int minor; Int patchlevel])
   ;;
 
+  let os_type = String Caml.Sys.os_type
+  ;;
+
   let rec to_expression loc t =
     match t with
     | Bool   x   -> ebool   ~loc x
@@ -158,6 +161,10 @@ end = struct
         ; txt = "ocaml_version"
         },
         Value.ocaml_version
+        ; { loc = Location.none
+        ; txt = "os_type"
+        },
+        Value.os_type
       ]
 
   let short_loc_string (loc : Location.t) =

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -37,7 +37,19 @@ module Value = struct
       (fun major minor patchlevel -> Tuple [Int major; Int minor; Int patchlevel])
   ;;
 
-  let os_type = String Caml.Sys.os_type
+  let os_type =
+    let os: string = Caml.Sys.os_type in
+    if (*os = "Unix"*) true then
+      String (
+        let ic = Unix.open_process_in "uname" in
+        let uname =
+          match Stdio.In_channel.input_line ic with
+            Some name -> name
+          | None -> "Unix"
+        in let () = Stdio.In_channel.close ic in
+        uname)
+      else
+          String os
   ;;
 
   let rec to_expression loc t =


### PR DESCRIPTION
Allow to test on `os_type`. In Revery we need to add some variant/code depending on the OS. and this will help. I have done 2 commit the first one is very lightweight and don't bring new dependencies. The second one bring unix dependencies to produce better variable. I can remove last commit.

Force push is just for the DCO bot. I have used unix and not core because for one function ... I think it is overkill.

Also sorry for formatting but their is no `.ocamlformat` file.