### PR TITLE
Make ppx_optcomp compatible with ppxlib.0.18.0

### DIFF
--- a/ppx_optcomp.opam
+++ b/ppx_optcomp.opam
@@ -15,7 +15,7 @@ depends: [
   "base"   {>= "v0.14" & < "v0.15"}
   "stdio"  {>= "v0.14" & < "v0.15"}
   "dune"   {>= "2.0.0"}
-  "ppxlib" {>= "0.11.0"}
+  "ppxlib" {>= "0.18.0"}
 ]
 synopsis: "Optional compilation for OCaml"
 description: "

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -241,7 +241,7 @@ let rec eval env e : Value.t =
   match e.pexp_desc with
   | Pexp_constant (Pconst_integer    (x, None)) -> Int (parse_int loc x)
   | Pexp_constant (Pconst_char    x       ) -> Char x
-  | Pexp_constant (Pconst_string (x, _   )) -> String x
+  | Pexp_constant (Pconst_string (x, _, _   )) -> String x
 
   | Pexp_construct ({ txt = Lident "true" ; _ }, None) -> Bool true
   | Pexp_construct ({ txt = Lident "false"; _ }, None) -> Bool false
@@ -361,7 +361,7 @@ and bind env patt value =
 
   | Ppat_constant (Pconst_integer    (x, None)), Int    y when parse_int loc x = y -> env
   | Ppat_constant (Pconst_char    x       ), Char   y when Char.equal   x y -> env
-  | Ppat_constant (Pconst_string (x, _   )), String y when String.equal x y -> env
+  | Ppat_constant (Pconst_string (x, _, _   )), String y when String.equal x y -> env
 
   | Ppat_construct ({ txt = Lident "true" ; _ }, None), Bool true  -> env
   | Ppat_construct ({ txt = Lident "false"; _ }, None), Bool false -> env

--- a/src/ppx_optcomp.ml
+++ b/src/ppx_optcomp.ml
@@ -81,7 +81,7 @@ module Ast_utils = struct
   let get_string ~loc payload =
     let e = get_expr ~loc payload in
     match e with
-    | { pexp_desc = Pexp_constant (Pconst_string (x, _ )); _ } -> x
+    | { pexp_desc = Pexp_constant (Pconst_string (x, _, _ )); _ } -> x
     | _ -> Location.raise_errorf ~loc "optcomp: invalid directive syntax, expected string"
 
 end


### PR DESCRIPTION
ppxlib.0.18.0 upgrades to the 4.11 AST which results in a change in string constants representation. This PR makes ppx_optcomp compatible with the latest ppxlib.

You might want for the actual release of ppxlib.0.18.0 before merging this!