### PR TITLE
Add upper bound on ppxlib

### DIFF
--- a/ppx_optcomp.opam
+++ b/ppx_optcomp.opam
@@ -14,7 +14,7 @@ depends: [
   "base"
   "stdio"
   "dune"   {>= "1.5.1"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.18.0"}
 ]
 synopsis: "Optional compilation for OCaml"
 description: "


### PR DESCRIPTION
0.18 ugrades the parsetree to 4.11 and breaks ppx_optcomp