### PR TITLE
Remove stdio and base as dependencies

### DIFF
--- a/ppx_optcomp.opam
+++ b/ppx_optcomp.opam
@@ -11,8 +11,6 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.2"}
-  "base"
-  "stdio"
   "dune"   {>= "1.5.1"}
   "ppxlib" {>= "0.9.0"}
 ]

--- a/src/cparser.ml
+++ b/src/cparser.ml
@@ -4,7 +4,7 @@
 
 open Ppxlib
 
-module Parsing  = Caml.Parsing
+module Parsing  = Stdlib.Parsing
 
 type lexer = Lexing.lexbuf -> Parser.token
 

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,3 @@
 (library (name ppx_optcomp) (public_name ppx_optcomp)
- (libraries compiler-libs.common base ppxlib stdio) (kind ppx_deriver)
+ (libraries compiler-libs.common ppxlib) (kind ppx_deriver)
  (preprocess no_preprocessing))

--- a/src/token.ml
+++ b/src/token.ml
@@ -1,4 +1,3 @@
-open Base
 open Ppxlib
 
 module Directive = struct
@@ -9,8 +8,8 @@ module Directive = struct
            Elifdef | Elifndef
 
   let matches ~expected matched =
-      String.(=) expected matched ||
-      String.(=) ("optcomp." ^ expected) matched
+      String.equal expected matched ||
+      String.equal ("optcomp." ^ expected) matched
 
   (* not using [matches] here because I'm pretty sure the pattern matching
      compiler will make this faster than string equality. *)
@@ -40,7 +39,7 @@ let make_directive name loc payload = match Directive.of_string_opt name with
   | Some dir -> Directive (dir, loc, payload)
   | None -> Location.raise_errorf ~loc "optcomp: unknown directive"
 
-let just_directives_exn ~loc ls = List.filter_map ls ~f:(fun token ->
+let just_directives_exn ~loc ls = ListLabels.filter_map ls ~f:(fun token ->
   match token with
   | Directive _ as dir -> Some dir
   | Block [] -> None


### PR DESCRIPTION
I'd like to use optcomp, but including base in one's dependency tree is
heavy. So I tried experimenting with removing stdio/base and it
seems like it was quite easy.